### PR TITLE
uid有用不能删

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 MANIFEST
 dist
+build/

--- a/weibo.py
+++ b/weibo.py
@@ -33,6 +33,7 @@ class Client(object):
 
         self.access_token = None
         self.expires_at = None
+        self.uid = None
         self.session = None
 
         # activate client directly if given acccess_token and expires_at
@@ -53,6 +54,7 @@ class Client(object):
         This token_info can be stored to directly activate client at next time.
         """
         return {
+            'uid': self.uid,
             'access_token': self.access_token,
             'expires_at': self.expires_at
         }
@@ -79,6 +81,7 @@ class Client(object):
         tk = json.loads(response.content)
 
         self._assert_error(tk)
+        self.uid = tk['uid']
         self.set_token(tk['access_token'], time.time() + int(tk['expires_in']))
 
     def set_token(self, access_token, expires_at):


### PR DESCRIPTION
场景是
我需要知道uid，因为在授权之后，我马上会去获取用户的信息（users/show），这个接口是需要uid作为参数的
而授权这次请求中，恰好给出了token相应的uid
我并不希望多请求一次oauth2/get_token_info接口才拿到uid，这样浪费了
所以uid还是留着吧
